### PR TITLE
Use same workers number as connections in pool

### DIFF
--- a/lopocs/greyhound.py
+++ b/lopocs/greyhound.py
@@ -2,6 +2,7 @@
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
 
 from flask import Response
 import numpy
@@ -377,7 +378,7 @@ def build_hierarchy_from_pg(session, lod, lod_max, bbox):
 
         # run leaf in threads
         futures = {}
-        with ThreadPoolExecutor(max_workers=8) as e:
+        with ThreadPoolExecutor(max_workers=cpu_count() * 2) as e:
             futures["nwd"] = e.submit(build_hierarchy_from_pg_single, session, lod, lod_max, bbox_nwd)
             futures["nwu"] = e.submit(build_hierarchy_from_pg_single, session, lod, lod_max, bbox_nwu)
             futures["ned"] = e.submit(build_hierarchy_from_pg_single, session, lod, lod_max, bbox_ned)


### PR DESCRIPTION
If we use more workers than there are connections to database in
connection pool, we can exhaust them when importing data. The program
then crash and leave the DB in an incomplete state.

@pblottiere WDYT? The crash is real, but I'm not sure it's the correct way to fix it (because we then have the same calculation done twice: here and in database.py).